### PR TITLE
Supports resources with dynamic counts

### DIFF
--- a/src/tfstate/base/resource_map.py
+++ b/src/tfstate/base/resource_map.py
@@ -70,6 +70,9 @@ class ResourceMap(object):
             resource_type = splitted_name[0]
             if resource_type == 'data':
                 resource_type = '_'.join(splitted_name[:-1])
+                # Handles case for dynamic count based resources example: data.null.data.source.tags.0
+                if resource_type not in ResourceMap.RESOURCE_MAP:
+                    resource_type = '_'.join(splitted_name[:-2])
 
         resource_class = ResourceMap.RESOURCE_MAP.get(resource_type, None)
         if resource_class is None:

--- a/tfstate_examples/other/null_resource/data_null_resource_example.json
+++ b/tfstate_examples/other/null_resource/data_null_resource_example.json
@@ -1,0 +1,21 @@
+{
+    "data.null_data_source.tags.0": {
+        "type": "null_data_source",
+        "primary": {
+            "id": "static",
+            "attributes": {
+                "has_computed_default": "default",
+                "id": "static",
+                "inputs.%": "3",
+                "inputs.key": "Name",
+                "inputs.propagate_at_launch": "true",
+                "inputs.value": "NullDataSourceTest",
+                "outputs.%": "3",
+                "outputs.key": "Name",
+                "outputs.propagate_at_launch": "true",
+                "outputs.value": "NullDataSourceTest",
+                "random": "76582349081"
+            }
+        }
+    }
+}

--- a/unit_tests/test_tfstate/test_provider/test_other/test_data_null_resource.py
+++ b/unit_tests/test_tfstate/test_provider/test_other/test_data_null_resource.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# Python stdlib
+import unittest
+
+# Python tfstate
+from tfstate.exceptions import InvalidResource
+from tfstate.base import Resource
+from tfstate.provider.other.null_data_source import NullDataSource
+
+# Unit tests
+from unit_tests.base import BaseResourceUnitTest
+
+
+class DataNullResourceUnitTest(BaseResourceUnitTest):
+    def test_object_constructor(self):
+        self.load_example_json('other/null_resource/data_null_resource_example.json')
+        resource_name, resource_data = self.example_data.popitem()
+        null_resource = NullDataSource(resource_name, resource_data)
+        self.assertIsInstance(null_resource, Resource, "NullDataSource object does not inherit from AwsResource")
+        self.assertEqual(null_resource.resource_type, "null_data_source", "Resource type is not null_data_source")
+        # Attribute checks
+        native_primary = null_resource.primary_data
+        self.assertEqual(null_resource.id, native_primary['id'], "Resource ID does not match")
+
+
+def suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTest(loader.loadTestsFromTestCase(DataNullResourceUnitTest))
+    return suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
Handles cases where dynamic counts of resources can come into play.

**Example**: Dynamic mapping of tags handled by data.null_data_source resource.